### PR TITLE
docs(readme): 更新项目文档结构和内容

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-## 概念
+## 概述
 
-### 概述
+### 简介
 
 基于 go-zero 框架的 1.9.4 版本、goctl 1.9.2 版本.
 
@@ -30,45 +30,10 @@ go-zero 是一个集成了各种工程实践的 web 和 rpc 框架，缩短从�
     
     持续更新中，敬请期待。
 
+### 环境要求
+- Golang >= 1.20
+- MySql >= 5.7
 
-### 安装开发工具
-
-#### wire
-```shell
-# wire 是一个依赖注入工具，用于解决 Go 语言中依赖注入的问题。通过 wire，您可以轻松地管理应用程序的依赖关系，并确保它们在编译时进行注入。
-$ go install github.com/google/wire/cmd/wire@latest
-
-# 验证安装
-$ wire
-```
-
-#### goctl 安装
-```shell
-# https://github.com/zeromicro/go-zero/releases/tag/tools%2Fgoctl%2Fv1.9.2
-# goctl 是 go-zero 微服务框架下的代码生成工具。使用 goctl 可显著提升开发效率，让开发人员将时间重点放在业务开发上，其功能有：api服务生成、rpc服务生成、model代码生成、模板管理。
-$ go install github.com/zeromicro/go-zero/tools/goctl@v1.9.2
-
-# 验证安装
-$ goctl --version
-```
-
-### Make 命令介绍
-
-Makefile 文件描述了 Linux 系统下项目工程的编译规则，只需要一个 `make bild` 命令，整个工程就开始自动构建项目环境，不再需要手动执行大量的 `go build` 命令，Makefile 文件定义了一系列规则，指明了源文件的编译顺序、依赖关系、是否需要重新编译等，可以输入 `make help` 查看命令集。
-
-```shell
-# 生成api代码文件，并且更新 swagger 接口文档
-$ make api
-
-# 生成model代码文件
-$ make model
-
-# 生成wire代码文件
-$ make wire
-
-# 构建项目
-$ make build env=dev|test|prod
-```
 
 ### 代码结构
 
@@ -100,52 +65,96 @@ $ make build env=dev|test|prod
 └── README.md                       项目说明文件
 ```
 
-### 环境要求
-- Golang >= 1.20
-- MySql >= 5.7
 
 
-## 快速开始实例
+## 安装开发工具
 
-### 初始化项目
+### wire
 
-#### 1. clone项目
+wire 是一个依赖注入工具，用于解决 Go 语言中依赖注入的问题。通过 wire，您可以轻松地管理应用程序的依赖关系，并确保它们在编译时进行注入。
+
+```shell
+# shell 安装
+$ go install github.com/google/wire/cmd/wire@latest
+
+# 验证安装
+$ wire
+```
+
+### goctl 安装
+
+goctl 是 go-zero 微服务框架下的代码生成工具。使用 goctl 可显著提升开发效率，让开发人员将时间重点放在业务开发上，其功能有：api服务生成、rpc服务生成、model代码生成、模板管理。
+
+```shell
+# 方式一（推荐）：shell 安装
+$ go install github.com/zeromicro/go-zero/tools/goctl@v1.9.2
+
+# 方式二：手动下载安装
+https://github.com/zeromicro/go-zero/releases/tag/tools%2Fgoctl%2Fv1.9.2
+
+# 验证安装
+$ goctl --version
+```
+
+## Make 命令介绍
+
+Makefile 文件描述了 Linux 系统下项目工程的编译规则，只需要一个 `make bild` 命令，整个工程就开始自动构建项目环境，不再需要手动执行大量的 `go build` 命令，Makefile 文件定义了一系列规则，指明了源文件的编译顺序、依赖关系、是否需要重新编译等，可以输入 `make help` 查看命令集。
+
+```shell
+# 查看 make 信息
+$ make
+
+# 构建并打包应用（根据 env=dev|test|prod 编译，生成 build/app 及 app.tar）
+$ make build
+
+# 根据 api.api 定义生成 Go API 代码与 Swagger 文档
+$ make api
+
+# 根据 wire.go 生成依赖注入代码（wire_gen.go）
+$ make wire
+
+# 根据 MySQL 表结构生成 Go Model 代码
+$ make model
+```
+
+## 快速开始示例
+
+### 1. clone项目
 
 ![初始化项目](deploy/access/快速开始/1初始化项目.jpg)
 
-#### 2. 打开项目
+### 2. 打开项目
 
 ![打开项目](deploy/access/快速开始/2打开项目.jpg)
 
-#### 3. 替换包名引用
+### 3. 替换包名引用
 
 ![替换包名引用](deploy/access/快速开始/3替换包名引用.jpg)
 
-#### 4. 启动go模块
+### 4. 启动go模块
 
 ![启动go模块](deploy/access/快速开始/4启动go模块.jpg)
 
-#### 5. 安装gosdk
+### 5. 安装gosdk
 
 ![下载依赖包](deploy/access/快速开始/5安装gosdk.png)
 
-#### 6. 下载依赖包
+### 6. 下载依赖包
 
 ![下载依赖包](deploy/access/快速开始/6下载依赖包.jpg)
 
-#### 7. 启动redis
+### 7. 启动redis
 
 ![启动redis](deploy/access/快速开始/7启动redis.jpg)
 
-#### 8. 启动项目
+### 8. 启动项目
 
 ![启动项目](deploy/access/快速开始/8启动项目.jpg)
 
-#### 9. 启动成功
+### 9. 启动成功
 
 ![启动项目](deploy/access/快速开始/9启动成功.jpg)
 
-#### 
 
 ## 常见问题
 ### 1. go mod tidy 超时 i/o timeout


### PR DESCRIPTION
- 将标题"概念"改为"概述"，"概述"改为"简介"
- 移除原有的安装开发工具章节内容
- 将环境要求从底部移到中间位置
- 重新组织文档结构，将安装开发工具和Make命令介绍放回文档前部
- 更新快速开始部分的标题格式，统一使用数字编号
- 添加详细的wire和goctl安装说明
- 补充完整的Make命令使用说明