### PR TITLE
refactor(app): 将main函数重命名为Start并创建新的入口文件

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1,4 +1,4 @@
-package main
+package app
 
 import (
 	"flag"
@@ -27,7 +27,7 @@ var (
 	}
 )
 
-func main() {
+func Start() {
 	flag.Parse()
 	var c *config.Config
 	err := conf.Load(*configFile, &c)

--- a/app/wire.go
+++ b/app/wire.go
@@ -1,15 +1,16 @@
 //go:build wireinject
 // +build wireinject
 
-package main
+package app
 
 import (
-	"github.com/google/wire"
 	"go-zero-box/app/internal/command"
 	"go-zero-box/app/internal/config"
 	"go-zero-box/app/internal/queue"
 	"go-zero-box/app/internal/svc"
 	"go-zero-box/pkg"
+
+	"github.com/google/wire"
 )
 
 type App struct {

--- a/app/wire_gen.go
+++ b/app/wire_gen.go
@@ -4,7 +4,7 @@
 //go:build !wireinject
 // +build !wireinject
 
-package main
+package app
 
 import (
 	"go-zero-box/app/internal/command"

--- a/main.go
+++ b/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "go-zero-box/app"
+
+func main() {
+	app.Start()
+}


### PR DESCRIPTION
- 将app包中的main函数重命名为Start函数
- 创建新的main.go文件作为应用入口点
- 更新包声明从main到app以避免冲突
- 移除原始main.go文件中的重复代码
- 通过导入app包并调用Start函数来启动应用
- 确保代码结构更清晰便于测试和维护